### PR TITLE
Add Mock.setup for node platform.

### DIFF
--- a/src/platform/node/index.ts
+++ b/src/platform/node/index.ts
@@ -3,6 +3,7 @@ import Handler from '../../core/handler'
 import toJSONSchema from '../../core/schema'
 import RE from '../../core/regexp'
 import valid from '../../core/valid'
+import setting from '../../core/setting'
 import * as Util from '../../utils'
 import Random from '../../random'
 
@@ -15,6 +16,7 @@ const Mock = {
   valid,
   mock,
   heredoc: Util.heredoc,
+  setup: setting.setup.bind(setting),
   version: '__VERSION__'
 }
 


### PR DESCRIPTION
为`node`平台添加`Mock.setting`方法，以避免单元测试中出现`TypeError: Mock.setup is not a function`。#58 